### PR TITLE
chore(namespaces): start adding per arch syscall numbers

### DIFF
--- a/pkg/libcontainer/namespaces/calls_linux.go
+++ b/pkg/libcontainer/namespaces/calls_linux.go
@@ -8,7 +8,6 @@ import (
 )
 
 const (
-	SYS_SETNS  = 308 // look here for different arch http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=7b21fddd087678a70ad64afc0f632e0f1071b092
 	TIOCGPTN   = 0x80045430
 	TIOCSPTLCK = 0x40045431
 )

--- a/pkg/libcontainer/namespaces/linux_x86_64.go
+++ b/pkg/libcontainer/namespaces/linux_x86_64.go
@@ -1,0 +1,7 @@
+// +build linux,x86_64
+package namespaces
+
+// Via http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=7b21fddd087678a70ad64afc0f632e0f1071b092
+const (
+	SYS_SETNS = 308
+)


### PR DESCRIPTION
I didn't move TIOCGPTN since it looks from a brief glance at the kernel
that the archs that matter right now (arm, x86) share the same
definition.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com (github: philips)
