### PR TITLE
Fix some nitpicky stuff about docker groups

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2554,17 +2554,17 @@ func (cli *DockerCli) CmdGroups(args ...string) error {
 	for _, command := range [][]string{
 		{"create", "Create a new group"},
 		{"list", "List all groups"},
-		{"rm", "Remove a group and all of it's containers"},
-		{"start", "Start all the container's in the group"},
-		{"stop", "Stop all the container's in the group"},
+		{"rm", "Remove a group and all of its containers"},
+		{"start", "Start all the containers in the group"},
+		{"stop", "Stop all the containers in the group"},
 		{"containers", "List all containers in a group"},
 	} {
-		description += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
+		description += fmt.Sprintf("    %-15.10s%s\n", command[0], command[1])
 	}
 
-	description += "\nRun 'docker groups COMMAND --help' for more information on a command."
+	description += "\nRun 'docker groups SUBCOMMAND --help' for more information on a command."
 
-	cmd := cli.Subcmd("groups", "[COMMAND]", description)
+	cmd := cli.Subcmd("groups", "[SUBCOMMAND]", description)
 
 	if err := cmd.Parse(args); err != nil {
 		return err

--- a/api/client/group_config.go
+++ b/api/client/group_config.go
@@ -12,28 +12,29 @@ import (
 )
 
 type GroupContainer struct {
-	Image string
-	Build string
+	Image string `yaml:"image"`
+	Build string `yaml:"build"`
 
-	Command     interface{}
-	Entrypoint  interface{}
-	Environment []string
+	Command     interface{} `yaml:"command"`
+	Entrypoint  interface{} `yaml:"entrypoint"`
+	Environment []string    `yaml:"environment"`
 
-	Ports   []string
-	Volumes []string
+	Ports       []string `yaml:"ports"`
+	Volumes     []string `yaml:"volumes"`
+	VolumesFrom []string `yaml:"volumes_from"`
 
-	User       string
+	User       string `yaml:"user"`
 	WorkingDir string `yaml:"working_dir"`
-	Tty        bool
+	Tty        bool   `yaml:"tty"`
 
-	Memory    string
+	Memory    string `yaml:"memory"`
 	CpuShares int64  `yaml:"cpu_shares"`
 	Cpuset    string `yaml:"cpu_set"`
 
-	Privileged bool
+	Privileged bool     `yaml:"privileged"`
 	CapAdd     []string `yaml:"cap_add"`
 	CapDrop    []string `yaml:"cap_drop"`
-	Devices    []string
+	Devices    []string `yaml:"devices"`
 }
 
 type GroupConfig struct {

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -58,6 +58,7 @@ func init() {
 			{"events", "Get real time events from the server"},
 			{"exec", "Run a command in an existing container"},
 			{"export", "Stream the contents of a container as a tar archive"},
+			{"groups", "Manage groups of containers"},
 			{"history", "Show the history of an image"},
 			{"images", "List images"},
 			{"import", "Create a new filesystem image from the contents of a tarball"},
@@ -84,6 +85,7 @@ func init() {
 			{"tag", "Tag an image into a repository"},
 			{"top", "Lookup the running processes of a container"},
 			{"unpause", "Unpause a paused container"},
+			{"up", "Create/update a group from a group.yml"},
 			{"version", "Show the Docker version information"},
 			{"wait", "Block until a container stops, then print its exit code"},
 		} {


### PR DESCRIPTION
ping @aanand
1. Grammar
2. Commands not listed in global command list, which made discovery
   difficult.
3. No YAML tags defined for some fields in group.yml.  Also no
   volumes_from.
4. COMMAND => SUBCOMMAND
5. Padding in subcommand list was not enough for "containers"

Docker-DCO-1.1-Signed-off-by: Nathan LeClaire nathan.leclaire@docker.com (github: nathanleclaire)
