### PR TITLE
add migration from old volume json

### DIFF
--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -53,10 +53,7 @@ func (r *Root) Create(name string) (volume.Volume, error) {
 	v, exists := r.volumes[name]
 	if !exists {
 		path := filepath.Join(r.path, name)
-		if err := os.Mkdir(path, 0755); err != nil {
-			if os.IsExist(err) {
-				return nil, ErrVolumeExists
-			}
+		if err := os.MkdirAll(path, 0755); err != nil {
 			return nil, err
 		}
 		v = &Volume{


### PR DESCRIPTION
On daemon restore iterate through old volumes config dir, read configs, and move non-binds to new volume path... removes old configs at the end
On container register, update container configs if `container.VolumeConfig == nil`